### PR TITLE
Implemented variable DateField type ('date' | 'datetime-local')

### DIFF
--- a/src/DateField.tsx
+++ b/src/DateField.tsx
@@ -3,10 +3,9 @@ import TextField, { TextFieldProps } from '@mui/material/TextField';
 import React from 'react';
 import { FieldProps, connectField, filterDOMProps } from 'uniforms';
 
-export type AllowedDateTypes = 'date' | 'datetime-local';
 /* istanbul ignore next */
 const DateConstructor = (typeof global === 'object' ? global : window).Date;
-const dateFormat = (value?: Date, type: AllowedDateTypes = 'datetime-local') =>
+const dateFormat = (value?: Date, type = 'datetime-local') =>
   value?.toISOString().slice(0, type === 'datetime-local' ? -8 : -14);
 const dateParse = (timestamp: number, onChange: DateFieldProps['onChange']) => {
   const date = new DateConstructor(timestamp);
@@ -22,7 +21,7 @@ export type DateFieldProps = FieldProps<
   TextFieldProps,
   {
     labelProps?: object;
-    type?: AllowedDateTypes;
+    type?: 'date' | 'datetime-local';
   }
 >;
 

--- a/src/DateField.tsx
+++ b/src/DateField.tsx
@@ -3,9 +3,11 @@ import TextField, { TextFieldProps } from '@mui/material/TextField';
 import React from 'react';
 import { FieldProps, connectField, filterDOMProps } from 'uniforms';
 
+export type AllowedDateTypes = 'date' | 'datetime-local';
 /* istanbul ignore next */
 const DateConstructor = (typeof global === 'object' ? global : window).Date;
-const dateFormat = (value?: Date) => value && value.toISOString().slice(0, -8);
+const dateFormat = (value?: Date, type: AllowedDateTypes = 'datetime-local') =>
+  value?.toISOString().slice(0, type === 'datetime-local' ? -8 : -14);
 const dateParse = (timestamp: number, onChange: DateFieldProps['onChange']) => {
   const date = new DateConstructor(timestamp);
   if (date.getFullYear() < 10000) {
@@ -18,7 +20,10 @@ const dateParse = (timestamp: number, onChange: DateFieldProps['onChange']) => {
 export type DateFieldProps = FieldProps<
   Date,
   TextFieldProps,
-  { labelProps?: object }
+  {
+    labelProps?: object;
+    type?: AllowedDateTypes;
+  }
 >;
 
 function Date(props: DateFieldProps) {
@@ -37,9 +42,11 @@ function Date(props: DateFieldProps) {
     readOnly,
     showInlineError,
     value,
+    type,
     ...rest
   } = props;
   const themeProps = useThemeProps({ props, name: 'MuiTextField' });
+  const dateType = type === 'date' ? type : 'datetime-local';
 
   return (
     <TextField
@@ -58,8 +65,8 @@ function Date(props: DateFieldProps) {
       }
       placeholder={placeholder}
       ref={inputRef}
-      type="datetime-local"
-      value={dateFormat(value) ?? ''}
+      type={dateType}
+      value={dateFormat(value, dateType) ?? ''}
       {...filterDOMProps(rest)}
     />
   );


### PR DESCRIPTION
Allow the user to choose the date HTML5 input type, being either `date` or `datetime-local`.

`type=datetime-local`
![image](https://user-images.githubusercontent.com/2383329/161319099-733eb423-0be4-4ab7-8a52-66867df9ad73.png)

`type=date`
![image](https://user-images.githubusercontent.com/2383329/161319203-bed25794-31eb-48c4-8cbe-9b36f792f0f6.png)
